### PR TITLE
Handle vertex colors and create shader helpers to use them

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,18 @@ freeGeometry(myGeom)
 myGraphic.freeGeometry(myGeom)
 ```
 
+If you want to write a shader that uses the builder's vertex colors, just make sure it has an `attribute vec4 aVertexColor` and p5 will send the colors to your shader. For convenience, there are two shader helpers that make use of the colors that mimic p5's standard shaders:
+```js
+// For full lighting (make sure you set up lights too):
+shadedModelColors()
+
+// For flat colors:
+flatModelColors()
+```
+
 ## Examples
+
+### A branching tree
 
 <table>
 <tr>
@@ -128,6 +139,86 @@ function draw() {
 <img src="https://user-images.githubusercontent.com/5315059/202913968-24da6b35-84b1-46a5-acce-fb07a32b6e33.png" />
 
 <a href="https://davepagurek.github.io/p5.buildGeometry/examples/tree">View live</a>
+
+</td>
+</tr>
+</table>
+
+### Using vertex colors
+
+<table>
+<tr>
+<td>
+
+```js
+let tree
+let button
+
+function setup() {
+  createCanvas(600, 600, WEBGL)
+  button = createButton('Regenerate')
+  button.mousePressed(makeTree)
+  makeTree()
+}
+
+function makeTree() {
+  if (tree) freeGeometry(tree)
+
+  tree = buildGeometry('tree', (builder) => {
+    const addBranch = (depth) => {
+      builder.push()
+      builder.translate(0, -50)
+      builder.fill('#857259')
+      builder.cylinder(15, 100)
+      builder.translate(0, -50)
+      if (depth >= 5) {
+        builder.fill('#8ae887')
+        builder.sphere(30)
+      } else {
+        const numChildren = round(random(1, 3))
+        for (let i = 0; i < numChildren; i++) {
+          builder.push()
+          builder.rotateZ(random(-0.3, 0.3) * PI)
+          builder.rotateY(random(TWO_PI))
+          addBranch(depth + 1)
+          builder.pop()
+        }
+      }
+      builder.pop()
+    }
+    builder.translate(0, 200)
+    builder.scale(0.7)
+    addBranch(0)
+  })
+}
+
+function draw() {
+  background(255)
+  orbitControl()
+  push()
+  noStroke()
+  if (millis() % 2000 < 1000) {
+    lights()
+    ambientMaterial(255)
+    shadedModelColors()
+  } else {
+    flatModelColors()
+  }
+  model(tree)
+  pop()
+}
+```
+
+</td>
+<td>
+
+Flat:
+<img src="https://user-images.githubusercontent.com/5315059/203878099-f5afa673-13aa-4b75-af92-140749b5d26a.png" />
+
+Shaded:
+<img src="https://user-images.githubusercontent.com/5315059/203878128-1b62a30e-3317-40e7-b6a7-25174c2834db.png" />
+
+<a href="https://davepagurek.github.io/p5.buildGeometry/examples/vertexColors">View live</a>
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the library to your source code, *after* loading p5 but *before* loading you
 
 ### Via CDN
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@davepagurek/p5.buildgeometry@0.0.1/build/p5.buildGeometry.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@davepagurek/p5.buildgeometry@0.0.3/build/p5.buildGeometry.js"></script>
 ```
 
 ### Self-hosted

--- a/examples/vertexColors/index.html
+++ b/examples/vertexColors/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><html lang="en"><head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.5.0/p5.js"></script>
+    <script src="../../build/p5.buildGeometry.js" type="text/javascript"></script>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <meta charset="utf-8">
+
+  </head>
+  <body>
+    <script src="sketch.js"></script>
+  
+
+</body></html>

--- a/examples/vertexColors/sketch.js
+++ b/examples/vertexColors/sketch.js
@@ -1,0 +1,56 @@
+let tree
+let button
+
+function setup() {
+  createCanvas(600, 600, WEBGL)
+  button = createButton('Regenerate')
+  button.mousePressed(makeTree)
+  makeTree()
+}
+
+function makeTree() {
+  if (tree) freeGeometry(tree)
+
+  tree = buildGeometry('tree', (builder) => {
+    const addBranch = (depth) => {
+      builder.push()
+      builder.translate(0, -50)
+      builder.fill('#857259')
+      builder.cylinder(15, 100)
+      builder.translate(0, -50)
+      if (depth >= 5) {
+        builder.fill('#8ae887')
+        builder.sphere(30)
+      } else {
+        const numChildren = round(random(1, 3))
+        for (let i = 0; i < numChildren; i++) {
+          builder.push()
+          builder.rotateZ(random(-0.3, 0.3) * PI)
+          builder.rotateY(random(TWO_PI))
+          addBranch(depth + 1)
+          builder.pop()
+        }
+      }
+      builder.pop()
+    }
+    builder.translate(0, 200)
+    builder.scale(0.7)
+    addBranch(0)
+  })
+}
+
+function draw() {
+  background(255)
+  orbitControl()
+  push()
+  noStroke()
+  if (millis() % 2000 < 1000) {
+    lights()
+    ambientMaterial(255)
+    shadedModelColors()
+  } else {
+    flatModelColors()
+  }
+  model(tree)
+  pop()
+}

--- a/examples/vertexColors/style.css
+++ b/examples/vertexColors/style.css
@@ -1,0 +1,7 @@
+html, body {
+  margin: 0;
+  padding: 0;
+}
+canvas {
+  display: block;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davepagurek/p5.buildgeometry",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "build/buildgeometry.js",
   "author": "Dave Pagurek <dave@davepagurek.com>",
   "license": "MIT",

--- a/src/p5.buildGeometry.ts
+++ b/src/p5.buildGeometry.ts
@@ -16,13 +16,24 @@ declare module 'P5' {
   interface __Graphics__ {
     buildGeometry(id: string, callback: GeometryBuilderCallback): P5.Geometry
     freeGeometry(geometry: P5.Geometry)
+    flatModelColors()
+    shadedModelColors()
+  }
+
+  interface RendererGL {
+    _vertexColorShader?: P5.Shader
+    _getVertexColorShader(): P5.Shader
   }
 }
 
 declare class p5 extends P5 {
   buildGeometry(id: string, callback: GeometryBuilderCallback): P5.Geometry
   freeGeometry(geometry: P5.Geometry)
+  flatModelColors()
+  shadedModelColors()
   static Graphics: new (...args: any[]) => P5.Graphics
+  static RendererGL: new (...args: any[]) => P5.RendererGL
+  static Shader: new (...args: any[]) => P5.Shader
 }
 
 type GeometryInput = Pick<P5.Geometry, 'vertices' | 'vertexNormals' | 'faces' | 'uvs' | 'edges' | 'vertexColors'>
@@ -90,7 +101,12 @@ export class GeometryBuilder {
     this.geometry.faces.push(...input.faces.map((f) => f.map((idx) => idx + startIdx) as [number, number, number]))
     this.geometry.uvs.push(...input.uvs)
     this.geometry.edges.push(...input.edges.map((edge) => edge.map((idx) => idx + startIdx) as [number, number]))
-    this.geometry.vertexColors.push(...input.vertexColors)
+    const vertexColors = [...input.vertexColors]
+    while (vertexColors.length < input.vertices.length * 4) {
+      // @ts-ignore
+      vertexColors.push(...this.scratch._renderer.curFillColor)
+    }
+    this.geometry.vertexColors.push(...vertexColors)
   }
 
   model(geometry: P5.Geometry) {
@@ -109,7 +125,7 @@ export class GeometryBuilder {
     // @ts-ignore
     const shapeMode = this.scratch._renderer.immediateMode.shapeMode as P5.BEGIN_KIND
 
-    if (shapeMode === this.p5.TRIANGLE_STRIP) {
+    if (shapeMode === this.p5.TRIANGLE_STRIP || this.p5.QUAD_STRIP) {
       for (let i = 2; i < geometry.vertices.length; i++) {
         if (i % 2 === 0) {
           faces.push([i, i - 1, i - 2])
@@ -301,3 +317,69 @@ function freeGeometry(shape: P5.Geometry) {
 
 p5.prototype.freeGeometry = freeGeometry
 p5.Graphics.prototype.freeGeometry = freeGeometry
+
+function flatModelColors() {
+  this.shader(this._renderer._getImmediateModeShader())
+}
+p5.prototype.flatModelColors = flatModelColors
+p5.Graphics.prototype.flatModelColors = flatModelColors
+
+const vertexColorShader = `
+precision highp float;
+precision highp int;
+
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec4 aVertexColor;
+attribute vec2 aTexCoord;
+
+uniform vec3 uAmbientColor[5];
+
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform mat3 uNormalMatrix;
+uniform int uAmbientLightCount;
+
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+varying vec3 vViewPosition;
+varying vec3 vAmbientColor;
+
+void main(void) {
+
+  vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
+
+  // Pass varyings to fragment shader
+  vViewPosition = viewModelPosition.xyz;
+  gl_Position = uProjectionMatrix * viewModelPosition;  
+
+  vNormal = uNormalMatrix * aNormal;
+  vTexCoord = aTexCoord;
+
+  vAmbientColor = vec3(0.0);
+  for (int i = 0; i < 5; i++) {
+    if (i < uAmbientLightCount) {
+      vAmbientColor += uAmbientColor[i];
+    }
+  }
+  vAmbientColor *= aVertexColor.xyz;
+}
+`
+
+p5.RendererGL.prototype._getVertexColorShader = function() {
+  if (!this._vertexColorShader) {
+    this._vertexColorShader = new p5.Shader(
+      this,
+      vertexColorShader,
+      // @ts-ignore
+      this._getLightShader()._fragSrc,
+    );
+  }
+
+  return this._vertexColorShader;
+}
+function shadedModelColors() {
+  this.shader(this._renderer._getVertexColorShader())
+}
+p5.prototype.shadedModelColors = shadedModelColors
+p5.Graphics.prototype.shadedModelColors = shadedModelColors


### PR DESCRIPTION
Added some methods to make use of the vertex colors in a p5.Geometry, since the default shaders don't make use of them.